### PR TITLE
COMPASS-339: Render GUID in base64

### DIFF
--- a/packages/hadron-react-bson/lib/binary-value.js
+++ b/packages/hadron-react-bson/lib/binary-value.js
@@ -8,16 +8,6 @@ const { truncate } = require('hadron-react-utils');
 const BASE_64 = 'base64';
 
 /**
- * The new UUID type.
- */
-const UUID = 4;
-
-/**
- * The old UUID type.
- */
-const UUID_OLD = 3;
-
-/**
  * The component class name.
  */
 const CLASS = 'element-value element-value-is-binary';
@@ -35,10 +25,7 @@ class Binary extends React.Component {
   renderValue() {
     const type = this.props.value.sub_type;
     const buffer = this.props.value.buffer;
-    if (type === UUID || type === UUID_OLD) {
-      return `Binary('${ truncate(buffer.toString(), 100) }')`;
-    }
-    return `Binary('${ truncate(buffer.toString(BASE_64), 100) }')`;
+    return `Binary('${truncate(buffer.toString(BASE_64), 100)}')`;
   }
 
   /**

--- a/packages/hadron-react-bson/lib/code-value.js
+++ b/packages/hadron-react-bson/lib/code-value.js
@@ -17,7 +17,7 @@ class Code extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const value = `Code('${ this.props.value.code }', ${ JSON.stringify(this.props.value.scope) })`;
+    const value = `Code('${this.props.value.code}', ${JSON.stringify(this.props.value.scope)})`;
     return React.createElement(
       'div',
       { className: CLASS, title: value },

--- a/packages/hadron-react-bson/lib/dbref-value.js
+++ b/packages/hadron-react-bson/lib/dbref-value.js
@@ -18,10 +18,10 @@ class DBRefValue extends React.Component {
    */
   render() {
     const dbref = this.props.value;
-    const value = `DBRef(${ dbref.namespace }, ${ String(dbref.oid) }, ${ dbref.db })`;
+    const value = `DBRef(${dbref.namespace}, ${String(dbref.oid)}, ${dbref.db})`;
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/lib/double-value.js
+++ b/packages/hadron-react-bson/lib/double-value.js
@@ -20,7 +20,7 @@ class Double extends React.Component {
     const value = String(this.props.value.value);
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/lib/int32-value.js
+++ b/packages/hadron-react-bson/lib/int32-value.js
@@ -20,7 +20,7 @@ class Int32 extends React.Component {
     const value = String(this.props.value.valueOf());
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/lib/key-value.js
+++ b/packages/hadron-react-bson/lib/key-value.js
@@ -17,10 +17,10 @@ class Key extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const value = `${ String(this.props.value.constructor.name) }()`;
+    const value = `${String(this.props.value.constructor.name)}()`;
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/lib/regex-value.js
+++ b/packages/hadron-react-bson/lib/regex-value.js
@@ -17,10 +17,10 @@ class Regex extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const value = `/${ this.props.value.pattern }/${ this.props.value.options }`;
+    const value = `/${this.props.value.pattern}/${this.props.value.options}`;
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/lib/string-value.js
+++ b/packages/hadron-react-bson/lib/string-value.js
@@ -19,8 +19,8 @@ class StringValue extends React.Component {
   render() {
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-string`, title: this.props.value },
-      `\"${ this.props.value }\"`
+      { className: `${CLASS} ${CLASS}-is-string`, title: this.props.value },
+      `\"${this.props.value}\"`
     );
   }
 }

--- a/packages/hadron-react-bson/lib/value.js
+++ b/packages/hadron-react-bson/lib/value.js
@@ -20,7 +20,7 @@ class Value extends React.Component {
     const value = String(this.props.value);
     return React.createElement(
       'div',
-      { className: `${ CLASS } ${ CLASS }-is-${ this.props.type.toLowerCase() }`, title: value },
+      { className: `${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`, title: value },
       value
     );
   }

--- a/packages/hadron-react-bson/src/binary-value.jsx
+++ b/packages/hadron-react-bson/src/binary-value.jsx
@@ -8,16 +8,6 @@ const { truncate } = require('hadron-react-utils');
 const BASE_64 = 'base64';
 
 /**
- * The new UUID type.
- */
-const UUID = 4;
-
-/**
- * The old UUID type.
- */
-const UUID_OLD = 3;
-
-/**
  * The component class name.
  */
 const CLASS = 'element-value element-value-is-binary';
@@ -35,9 +25,6 @@ class Binary extends React.Component {
   renderValue() {
     const type = this.props.value.sub_type;
     const buffer = this.props.value.buffer;
-    if (type === UUID || type === UUID_OLD) {
-      return `Binary('${truncate(buffer.toString(), 100)}')`;
-    }
     return `Binary('${truncate(buffer.toString(BASE_64), 100)}')`;
   }
 

--- a/packages/hadron-react-bson/test/binary-value.test.jsx
+++ b/packages/hadron-react-bson/test/binary-value.test.jsx
@@ -4,6 +4,8 @@ const { shallow } = require('enzyme');
 const { Binary } = require('bson');
 const { BinaryValue } = require('../');
 
+const TESTING_BASE64 = Buffer.from('testing').toString('base64');
+
 describe('<BinaryValue />', () => {
   context('when the type is an old uuid', () => {
     const binary = new Binary('testing', 3);
@@ -18,11 +20,11 @@ describe('<BinaryValue />', () => {
     });
 
     it('sets the title', () => {
-      expect(component.props().title).to.equal('Binary(\'testing\')');
+      expect(component.props().title).to.equal(`Binary('${TESTING_BASE64}')`);
     });
 
     it('sets the value', () => {
-      expect(component.text()).to.equal('Binary(\'testing\')');
+      expect(component.text()).to.equal(`Binary('${TESTING_BASE64}')`);
     });
   });
 
@@ -39,11 +41,11 @@ describe('<BinaryValue />', () => {
     });
 
     it('sets the title', () => {
-      expect(component.props().title).to.equal('Binary(\'testing\')');
+      expect(component.props().title).to.equal(`Binary('${TESTING_BASE64}')`);
     });
 
     it('sets the value', () => {
-      expect(component.text()).to.equal('Binary(\'testing\')');
+      expect(component.text()).to.equal(`Binary('${TESTING_BASE64}')`);
     });
   });
 

--- a/packages/hadron-react-bson/test/binary-value.test.jsx
+++ b/packages/hadron-react-bson/test/binary-value.test.jsx
@@ -47,6 +47,20 @@ describe('<BinaryValue />', () => {
     });
   });
 
+  context('when the type is a GUID', () => {
+    const buffer = Buffer.from('WBAc3FDBDU+Zh/cBQFPc3Q==', 'base64');
+    const binary = new Binary(buffer, 4);
+    const component = shallow(<BinaryValue type="Binary" value={binary} />);
+
+    it('title is base64 encoded', () => {
+      expect(component.props().title).to.equal('Binary(\'WBAc3FDBDU+Zh/cBQFPc3Q==\')');
+    });
+
+    it('value is base64 encoded', () => {
+      expect(component.text()).to.equal('Binary(\'WBAc3FDBDU+Zh/cBQFPc3Q==\')');
+    });
+  });
+
   context('when the type is not a uuid', () => {
     const binary = new Binary('testing', 2);
     const component = shallow(<BinaryValue type="Binary" value={binary} />);


### PR DESCRIPTION
Tested in Compass via:

    pzrq@rocket:~/Projects/compass$ npm link ../hadron-react/packages/hadron-react-bson

## BEFORE

<img width="413" alt="screen shot 2017-05-18 at 5 08 07 pm" src="https://cloud.githubusercontent.com/assets/1217010/26190514/35eee6c4-3bed-11e7-91c7-4f5ce4fd3c0b.png">

## AFTER

<img width="416" alt="screen shot 2017-05-18 at 5 12 57 pm" src="https://cloud.githubusercontent.com/assets/1217010/26190523/41fadbe4-3bed-11e7-9538-14e74aead411.png">
