### PR TITLE
COMPASS-1170: Create <InfoSprinkle> react component

### DIFF
--- a/packages/hadron-react-components/lib/index.js
+++ b/packages/hadron-react-components/lib/index.js
@@ -1,3 +1,4 @@
+module.exports.InfoSprinkle = require('./info-sprinkle');
 module.exports.ModalStatusMessage = require('./modal-status-message');
 module.exports.StatusRow = require('./status-row');
 module.exports.OptionSelector = require('./option-selector');

--- a/packages/hadron-react-components/lib/info-sprinkle.js
+++ b/packages/hadron-react-components/lib/info-sprinkle.js
@@ -1,0 +1,29 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+/**
+ * An info sprinkle which can be clicked to perform the work in the
+ * onClickHandler. The onClickHandler receives the helpLink argument.
+ */
+class InfoSprinkle extends React.Component {
+
+  /**
+   * Render the input.
+   *
+   * @returns {React.Component} The react component.
+   */
+  render() {
+    return React.createElement('i', { className: 'info-sprinkle',
+      onClick: this.props.onClickHandler.bind(this, this.props.helpLink)
+    });
+  }
+}
+
+InfoSprinkle.displayName = 'InfoSprinkle';
+
+InfoSprinkle.propTypes = {
+  onClickHandler: PropTypes.func.isRequired, // e.g. require('electron').shell.openExternal
+  helpLink: PropTypes.string.isRequired
+};
+
+module.exports = InfoSprinkle;

--- a/packages/hadron-react-components/package.json
+++ b/packages/hadron-react-components/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "mocha": "^3.1.2",
-    "mongodb-js-precommit": "^0.2.9"
+    "mongodb-js-precommit": "^0.2.9",
+    "sinon-chai": "^2.10.0"
   }
 }

--- a/packages/hadron-react-components/src/index.js
+++ b/packages/hadron-react-components/src/index.js
@@ -1,3 +1,4 @@
+module.exports.InfoSprinkle = require('./info-sprinkle');
 module.exports.ModalStatusMessage = require('./modal-status-message');
 module.exports.StatusRow = require('./status-row');
 module.exports.OptionSelector = require('./option-selector');

--- a/packages/hadron-react-components/src/info-sprinkle.jsx
+++ b/packages/hadron-react-components/src/info-sprinkle.jsx
@@ -1,0 +1,31 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+/**
+ * An info sprinkle which can be clicked to perform the work in the
+ * onClickHandler. The onClickHandler receives the helpLink argument.
+ */
+class InfoSprinkle extends React.Component {
+
+  /**
+   * Render the input.
+   *
+   * @returns {React.Component} The react component.
+   */
+  render() {
+    return (
+      <i className="info-sprinkle"
+        onClick={this.props.onClickHandler.bind(this, this.props.helpLink)}
+      />
+    );
+  }
+}
+
+InfoSprinkle.displayName = 'InfoSprinkle';
+
+InfoSprinkle.propTypes = {
+  onClickHandler: PropTypes.func.isRequired,  // e.g. require('electron').shell.openExternal
+  helpLink: PropTypes.string.isRequired
+};
+
+module.exports = InfoSprinkle;

--- a/packages/hadron-react-components/test/info-sprinkle.test.jsx
+++ b/packages/hadron-react-components/test/info-sprinkle.test.jsx
@@ -1,0 +1,32 @@
+const React = require('react');
+const { expect } = require('chai');
+const { shallow } = require('enzyme');
+const { InfoSprinkle } = require('../');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+// For `expect(mySpy).to.have.been.calledWith("foo");` syntax
+chai.use(sinonChai);
+
+const HELP_URL = 'https://github.com/mongodb-js/hadron-react/';
+
+describe('<InfoSprinkle />', () => {
+  let onClickSpy;
+  let component;
+
+  before(()=> {
+    onClickSpy = sinon.spy();
+    component = shallow(
+      <InfoSprinkle helpLink={HELP_URL} onClickHandler={onClickSpy} />
+    );
+  });
+
+  it('has the info-sprinkle CSS class', () => {
+    expect(component.hasClass('info-sprinkle')).to.equal(true);
+  });
+  it('links to a help URL', () => {
+    component.simulate('click');
+    expect(onClickSpy).to.have.been.calledWith(HELP_URL);
+  });
+});


### PR DESCRIPTION
This PR adds an `<InfoSprinkle>` react component loosely based on the one in the Compass Indexes Tab and some enzyme tests.

There should be no visible change to Compass to the any of the info sprinkles, Indexes Tab and Create Database/Collection dialog's capped collection icon. Tested in Compass locally using:

     ~/Projects/compass$ npm link ../hadron-react/packages/hadron-react-components/

# Testing done

## Indexes Tab Before

<img width="1020" alt="before" src="https://cloud.githubusercontent.com/assets/1217010/26303273/776b6bd2-3f2a-11e7-905b-701515318312.png">


## Indexes Tab After

<img width="1027" alt="after" src="https://cloud.githubusercontent.com/assets/1217010/26303362/cd6ee77a-3f2a-11e7-9209-dc969d723249.png">

### Mouseover version

<img width="117" alt="screen shot 2017-05-22 at 8 12 53 pm" src="https://cloud.githubusercontent.com/assets/1217010/26303451/10a9cd3e-3f2b-11e7-93fa-5d3483653c01.png">

## Create Collection After

<img width="488" alt="screen shot 2017-05-22 at 8 14 35 pm" src="https://cloud.githubusercontent.com/assets/1217010/26303537/4e1850fa-3f2b-11e7-8b71-384a8d30075f.png">


Other `help` class items are presently unchanged, e.g. on the Schema Tab:

<img width="668" alt="schema tab help unchanged" src="https://cloud.githubusercontent.com/assets/1217010/26303678/c2802bf2-3f2b-11e7-963d-fc9d4a1b6b80.png">

I did notice a new exception with this `npm link`-based version, which led to the following so I think it's just a false positive that it is likely to go away once this PR is merged and `hadron-react-components` can be `npm install`-ed without `npm link`:
https://facebook.github.io/react/warnings/refs-must-have-owner.html