### PR TITLE
Allow Animated Buttons to be Disabled

### DIFF
--- a/packages/hadron-react-buttons/lib/animated-icon-text-button.js
+++ b/packages/hadron-react-buttons/lib/animated-icon-text-button.js
@@ -71,7 +71,8 @@ class AnimatedIconTextButton extends React.Component {
         type: BUTTON,
         'data-test-id': this.props.dataTestId,
         className: this.props.className,
-        onClick: this.handleClick.bind(this) },
+        onClick: this.handleClick.bind(this),
+        disabled: this.props.disabled },
       this.renderIcon(),
       this.props.text
     );
@@ -87,7 +88,8 @@ AnimatedIconTextButton.propTypes = {
   iconClassName: PropTypes.string.isRequired,
   animatingIconClassName: PropTypes.string.isRequired,
   dataTestId: PropTypes.string,
-  stopAnimationListenable: PropTypes.any.isRequired
+  stopAnimationListenable: PropTypes.any.isRequired,
+  disabled: PropTypes.bool
 };
 
 module.exports = AnimatedIconTextButton;

--- a/packages/hadron-react-buttons/src/animated-icon-text-button.jsx
+++ b/packages/hadron-react-buttons/src/animated-icon-text-button.jsx
@@ -74,7 +74,8 @@ class AnimatedIconTextButton extends React.Component {
         type={BUTTON}
         data-test-id={this.props.dataTestId}
         className={this.props.className}
-        onClick={this.handleClick.bind(this)}>
+        onClick={this.handleClick.bind(this)}
+        disabled={this.props.disabled}>
         {this.renderIcon()}
         {this.props.text}
       </button>
@@ -91,7 +92,8 @@ AnimatedIconTextButton.propTypes = {
   iconClassName: PropTypes.string.isRequired,
   animatingIconClassName: PropTypes.string.isRequired,
   dataTestId: PropTypes.string,
-  stopAnimationListenable: PropTypes.any.isRequired
+  stopAnimationListenable: PropTypes.any.isRequired,
+  disabled: PropTypes.bool
 };
 
 module.exports = AnimatedIconTextButton;


### PR DESCRIPTION
Small PR adding a `disabled` bool proptype to animated icon text buttons. 

**Use case:**
Compass uses animated icon text buttons for it's pagination controls in the document view. We need to disable these buttons in certain cases: **(a)** the previous button is disabled when the user is on the first page, and **(b)** the next button is disabled when the user is on the last page.