### PR TITLE
:pushpin: lerna.json > lerna@2.6.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.38",
+  "lerna": "2.6.0",
   "version": "1.12.0",
   "packages": [
     "packages/*"


### PR DESCRIPTION
Note: `package.json` already has `"lerna": "2.6.0"` included, and a `git commit` hook throws errors if I otherwise try to commit.

There are quite a few changes since `2.0.0-beta.38`, e.g. some `lerna publish` changes in the RC versions. See:
https://github.com/lerna/lerna/blob/master/CHANGELOG.md#v260-2018-01-08

Documentation of `lerna.json`:
https://github.com/lerna/lerna#lernajson