### PR TITLE
:white_check_mark: Add node 8 LTS to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 sudo: false
 node_js:
   - 7
+  - 8
 script: npm run-script ci


### PR DESCRIPTION
See CHARTS-580 for the longer term motivation.

I can see it is basically free (actually Node 8 is 27% faster at 105s when compared to Node 7 at 144s in this one data point):
https://travis-ci.org/mongodb-js/hadron-react/builds/330307830