### PR TITLE
CLOUDP-32660: Display timezones on date fields

### DIFF
--- a/packages/hadron-react-bson/lib/date-value.js
+++ b/packages/hadron-react-bson/lib/date-value.js
@@ -20,7 +20,7 @@ var CLASS = 'element-value element-value-is-date';
 /**
  * The date format.
  */
-var FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
+var FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSZ';
 
 /**
  * BSON Date component.

--- a/packages/hadron-react-bson/src/date-value.jsx
+++ b/packages/hadron-react-bson/src/date-value.jsx
@@ -10,7 +10,7 @@ const CLASS = 'element-value element-value-is-date';
 /**
  * The date format.
  */
-const FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
+const FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSZ';
 
 /**
  * BSON Date component.

--- a/packages/hadron-react-bson/test/date-value.test.jsx
+++ b/packages/hadron-react-bson/test/date-value.test.jsx
@@ -4,27 +4,6 @@ const { shallow } = require('enzyme');
 const { DateValue } = require('../');
 
 describe('<DateValue />', () => {
-  const date = new Date('2016-01-01 12:00:00');
-  const component = shallow(<DateValue type="Date" value={date} />);
-
-  it('sets the base class', () => {
-    expect(component.hasClass('element-value')).to.equal(true);
-  });
-
-  it('sets the type class', () => {
-    expect(component.hasClass('element-value-is-date')).to.equal(true);
-  });
-
-  it('sets the title', () => {
-    expect(component.props().title).to.contain('2016-01-01');
-  });
-
-  it('sets the value', () => {
-    expect(component.text()).to.contain('2016-01-01');
-  });
-});
-
-describe('<DateValue />', () => {
   describe('without a timezone', function() {
     const date = new Date('2016-01-01 12:00:00');
     const component = shallow(<DateValue type="Date" value={date} />);
@@ -52,7 +31,7 @@ describe('<DateValue />', () => {
 
   describe('with a timezone', function() {
     const date = new Date(1451667600000);
-    const component = shallow(<DateValue type="Date" value={date} tz={'America/Los_Angeles'} />);
+    const component = shallow(<DateValue type="Date" value={date} tz={'UTC'} />);
 
     it('sets the base class', () => {
       expect(component.hasClass('element-value')).to.equal(true);
@@ -71,7 +50,11 @@ describe('<DateValue />', () => {
     });
 
     it('sets the time value', () => {
-      expect(component.text()).to.contain('09:00:00');
+      expect(component.text()).to.contain('17:00:00');
+    });
+
+    it('includes the timezone', () => {
+      expect(component.text()).to.contain('+00:00');
     });
   });
 });


### PR DESCRIPTION
As a part of [CLOUDP-32660](https://jira.mongodb.org/browse/CLOUDP-32660)

Dates in compass and data explorer will now show the timezones as an offset from UTC (moment docs [here]( https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/)). 
Dates are now in the format: 2019-10-02 05:00:00.000+00:00

Cleaned up the `data-value` tests to remove duplicates and check the new timezone format. I changed the tested timezone from LA time to UTC because the offset of LA time might vary throughout the year (daylight saving time) this could cause the `includes-timezone` test to fail  