### PR TITLE
CLOUDP-34934 Data Explorer fails to work with Date fields through Safari

### DIFF
--- a/packages/hadron-react-bson/lib/date-value.js
+++ b/packages/hadron-react-bson/lib/date-value.js
@@ -20,7 +20,7 @@ var CLASS = 'element-value element-value-is-date';
 /**
  * The date format.
  */
-var FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSZ';
+var FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
 /**
  * BSON Date component.

--- a/packages/hadron-react-bson/src/date-value.jsx
+++ b/packages/hadron-react-bson/src/date-value.jsx
@@ -10,7 +10,7 @@ const CLASS = 'element-value element-value-is-date';
 /**
  * The date format.
  */
-const FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSZ';
+const FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
 /**
  * BSON Date component.


### PR DESCRIPTION
Fixing a bug in date explorer in Safari where all dates are marked as invalid after being formatted [CLOUDP-34934](https://jira.mongodb.org/browse/CLOUDP-34934)

Change to using ISO date format (as Safari's implementation of Date fails to parse milliseconds in all other formats)